### PR TITLE
Wrap sound direction and some more EFX properties

### DIFF
--- a/include/OALWrapper/OAL_Device.h
+++ b/include/OALWrapper/OAL_Device.h
@@ -89,6 +89,7 @@ public:
 	void SetListenerPosition (const float* apPos );
 	void SetListenerVelocity (const float* apVel );
 	void SetListenerOrientation (const float* apForward, const float* apUp);
+	void SetListenerMetersPerUnit (const float afValue );
 
 
 	////////////////////////////////////////////////////////

--- a/include/OALWrapper/OAL_EFX.h
+++ b/include/OALWrapper/OAL_EFX.h
@@ -66,6 +66,12 @@ void OAL_Source_SetDirectFilter( int alSourceHandle, cOAL_Filter* apFilter );
 void OAL_Source_SetAuxSend ( int alSourceHandle, int alAuxSend, int alSlotHandle, cOAL_Filter* apFilter );
 void OAL_Source_SetAuxSendSlot ( int alSourceHandle, int alAuxSend, int alSlotHandle);
 void OAL_Source_SetAuxSendFilter ( int alSourceHandle, int alAuxSend, cOAL_Filter* apFilter );
+void OAL_Source_SetConeOuterGainHF ( const int alSourceHandle, const float afGain );
+void OAL_Source_SetAirAbsorptionFactor ( const int alSourceHandle, const float afFactor );
+void OAL_Source_SetRoomRolloffFactor ( const int alSourceHandle, const float afFactor );
+void OAL_Source_SetDirectFilterGainHFAuto ( const int alSourceHandle, bool abAuto = true );
+void OAL_Source_SetAuxSendFilterGainAuto ( const int alSourceHandle, bool abAuto = true);
+void OAL_Source_SetAuxSendFilterGainHFAuto ( const int alSourceHandle, bool abAuto = true );
 
 void OAL_Source_SetFiltering( int alSourceHandle, bool abEnabled, int alFlags);
 void OAL_Source_SetFilterType( int alSourceHandle, eOALFilterType aeType);

--- a/include/OALWrapper/OAL_Playback.h
+++ b/include/OALWrapper/OAL_Playback.h
@@ -38,6 +38,10 @@ void		OAL_Source_SetAttributes ( const int alSource, const float* apPos, const f
 void		OAL_Source_SetMinMaxDistance ( const int alSource, const float afMin, const float afMax );
 void		OAL_Source_SetPositionRelative ( const int alSource, const bool abRelative );
 void		OAL_Source_SetPriority ( const int alSource, const unsigned int alPriority );
+void		OAL_Source_SetConeOuterGain ( const int alSource, const float afGain );
+void		OAL_Source_setConeInnerAngle ( const int alSource, const float afAngle );
+void		OAL_Source_setConeOuterAngle ( const int alSource, const float afAngle );
+void		OAL_Source_SetDirection ( const int alSource, const float* apDir );
 
 unsigned  int	OAL_Source_GetPriority ( const int alSource );
 float OAL_Source_GetPitch(const int alSource);
@@ -49,7 +53,7 @@ const bool	OAL_Source_IsBufferUnderrun ( const int alSource );
 
 void		OAL_Listener_SetAttributes ( const float* apPos, const float* apVel, const float* apForward, const float* apUpward ); 
 void		OAL_Listener_SetMasterVolume ( const float afVolume );
-
+void		OAL_Listener_SetMetersPerUnit (const float afValue );
 
 void	OAL_Source_SetElapsedTime( const int alSource, double afTime );
 double	OAL_Source_GetElapsedTime( const int alSource );

--- a/include/OALWrapper/OAL_Source.h
+++ b/include/OALWrapper/OAL_Source.h
@@ -106,6 +106,10 @@ public:
 	void SetVelocity(const float* apVel);
 	void SetLoop(bool abLoop);
     void SetMinMaxDistance(const float afMin, const float afMax);
+    void SetConeOuterGain(const float afGain);
+    void setConeInnerAngle(const float afAngle);
+    void setConeOuterAngle(const float afAngle);
+    void SetDirection(const float* apDir);
 
 	void SetElapsedTime(double afTime);
 
@@ -134,6 +138,12 @@ public:
 	void SetAuxSend(int alSendId, cOAL_EffectSlot* apSlot, cOAL_Filter* apFilter);
 	void SetAuxSendSlot(int alSendId, cOAL_EffectSlot* apSlot );
 	void SetAuxSendFilter(int alSendId, cOAL_Filter* apFilter );
+	void SetConeOuterGainHF(const float afGain);
+	void SetAirAbsorptionFactor(const float afFactor);
+	void SetRoomRolloffFactor(const float afFactor);
+	void SetDirectFilterGainHFAuto(bool abAuto = true);
+	void SetAuxSendFilterGainAuto(bool abAuto = true);
+	void SetAuxSendFilterGainHFAuto(bool abAuto = true);
 
 	// Built in filter methods
 	void SetFilterType ( eOALFilterType aeType );

--- a/sources/OAL_Device.cpp
+++ b/sources/OAL_Device.cpp
@@ -565,6 +565,18 @@ void cOAL_Device::SetListenerOrientation(const float* apForward, const float* ap
 
 //-------------------------------------------------------------------------
 
+void cOAL_Device::SetListenerMetersPerUnit (const float afValue )
+{
+	if (!mbEFXActive)
+		return;
+	DEF_FUNC_NAME ("cOAL_Device::SetListenerMetersPerUnit()");
+	FUNC_USES_AL;
+
+	RUN_AL_FUNC(alListenerf ( AL_METERS_PER_UNIT, afValue ));
+}
+
+//-------------------------------------------------------------------------
+
 /////////////////////////////////////////////////////////////
 /////////////////////////////////////////////////////////////
 // Playback Management

--- a/sources/OAL_EFX.cpp
+++ b/sources/OAL_EFX.cpp
@@ -369,6 +369,96 @@ void OAL_Source_SetFilterGainHF( int alSourceHandle, float afGainHF)
 	}
 }
 
+void OAL_Source_SetConeOuterGainHF ( const int alSourceHandle, const float afGain )
+{
+	if (gpDevice == NULL)
+		return;
+
+	cOAL_Source* pSource = gpDevice->GetSource(alSourceHandle);
+
+	if (pSource)
+	{
+		pSource->Lock();
+		pSource->SetConeOuterGainHF(afGain);
+		pSource->Unlock();
+	}
+}
+
+void OAL_Source_SetAirAbsorptionFactor ( const int alSourceHandle, const float afFactor )
+{
+	if (gpDevice == NULL)
+		return;
+
+	cOAL_Source* pSource = gpDevice->GetSource(alSourceHandle);
+
+	if (pSource)
+	{
+		pSource->Lock();
+		pSource->SetAirAbsorptionFactor(afFactor);
+		pSource->Unlock();
+	}
+}
+
+void OAL_Source_SetRoomRolloffFactor ( const int alSourceHandle, const float afFactor )
+{
+	if (gpDevice == NULL)
+		return;
+
+	cOAL_Source* pSource = gpDevice->GetSource(alSourceHandle);
+
+	if (pSource)
+	{
+		pSource->Lock();
+		pSource->SetRoomRolloffFactor(afFactor);
+		pSource->Unlock();
+	}
+}
+
+void OAL_Source_SetDirectFilterGainHFAuto ( const int alSourceHandle, bool abAuto )
+{
+	if (gpDevice == NULL)
+		return;
+
+	cOAL_Source* pSource = gpDevice->GetSource(alSourceHandle);
+
+	if (pSource)
+	{
+		pSource->Lock();
+		pSource->SetDirectFilterGainHFAuto(abAuto);
+		pSource->Unlock();
+	}
+}
+
+void OAL_Source_SetAuxSendFilterGainAuto ( const int alSourceHandle, bool abAuto )
+{
+	if (gpDevice == NULL)
+		return;
+
+	cOAL_Source* pSource = gpDevice->GetSource(alSourceHandle);
+
+	if (pSource)
+	{
+		pSource->Lock();
+		pSource->SetAuxSendFilterGainAuto(abAuto);
+		pSource->Unlock();
+	}
+}
+
+void OAL_Source_SetAuxSendFilterGainHFAuto ( const int alSourceHandle, bool abAuto )
+{
+	if (gpDevice == NULL)
+		return;
+
+	cOAL_Source* pSource = gpDevice->GetSource(alSourceHandle);
+
+	if (pSource)
+	{
+		pSource->Lock();
+		pSource->SetAuxSendFilterGainHFAuto(abAuto);
+		pSource->Unlock();
+	}
+}
+
 
 ///////////////////////////////////////////////////////////////
 /*

--- a/sources/OAL_Playback.cpp
+++ b/sources/OAL_Playback.cpp
@@ -296,6 +296,17 @@ void OAL_Listener_SetMasterVolume ( float afVolume )
 }
 
 ///////////////////////////////////////////////////////////
+////	void OAL_Listener_SetMetersPerUnit (const float afValue )
+////	-	the relationship between the units passed to OpenAL calls such as positions and the real-world
+///////////////////////////////////////////////////////////
+
+void OAL_Listener_SetMetersPerUnit (const float afValue )
+{
+	if (gpDevice == NULL) return;
+	gpDevice->SetListenerMetersPerUnit(afValue);
+}
+
+///////////////////////////////////////////////////////////
 ////	void OAL_Source_SetPriority ( const int alSource, const unsigned int alPriority )
 ////	-	Sets the priority of the specified source
 ///////////////////////////////////////////////////////////
@@ -331,6 +342,74 @@ unsigned int OAL_Source_GetPriority ( const int alSource )
 	
 	return lPriority;
 
+}
+
+///////////////////////////////////////////////////////////
+////	void OAL_Source_SetConeOuterGain ( const int alSource, const float afGain )
+////	-	the factor with which AL_GAIN is multiplied to determine the effective gain outside the cone defined by the outer angle
+///////////////////////////////////////////////////////////
+
+void OAL_Source_SetConeOuterGain ( const int alSource, const float afGain )
+{
+	if (gpDevice == NULL) return;
+	cOAL_Source* pSource = gpDevice->GetSource(alSource);
+	if (pSource)
+	{
+		pSource->Lock();
+		pSource->SetConeOuterGain(afGain);
+		pSource->Unlock();
+	}
+}
+
+///////////////////////////////////////////////////////////
+////	void OAL_Source_setConeInnerAngle ( const int alSource, const float afAngle )
+////	-	Sets inner angle of the sound cone, in degrees
+///////////////////////////////////////////////////////////
+
+void OAL_Source_setConeInnerAngle ( const int alSource, const float afAngle )
+{
+	if (gpDevice == NULL) return;
+	cOAL_Source* pSource = gpDevice->GetSource(alSource);
+	if (pSource)
+	{
+		pSource->Lock();
+		pSource->setConeInnerAngle(afAngle);
+		pSource->Unlock();
+	}
+}
+
+///////////////////////////////////////////////////////////
+////	void OAL_Source_setConeOuterAngle ( const int alSource, const float afAngle )
+////	-	Sets outer angle of the sound cone, in degrees
+///////////////////////////////////////////////////////////
+
+void OAL_Source_setConeOuterAngle ( const int alSource, const float afAngle )
+{
+	if (gpDevice == NULL) return;
+	cOAL_Source* pSource = gpDevice->GetSource(alSource);
+	if (pSource)
+	{
+		pSource->Lock();
+		pSource->setConeOuterAngle(afAngle);
+		pSource->Unlock();
+	}
+}
+
+///////////////////////////////////////////////////////////
+////	void OAL_Source_SetDirection ( const int alSource, const float* apDir )
+////	-	Sets sound direction for the source
+///////////////////////////////////////////////////////////
+
+void OAL_Source_SetDirection ( const int alSource, const float* apDir )
+{
+	if (gpDevice == NULL) return;
+	cOAL_Source* pSource = gpDevice->GetSource(alSource);
+	if (pSource)
+	{
+		pSource->Lock();
+		pSource->SetDirection(apDir);
+		pSource->Unlock();
+	}
 }
 
 ///////////////////////////////////////////////////////////

--- a/sources/OAL_Source.cpp
+++ b/sources/OAL_Source.cpp
@@ -658,6 +658,111 @@ void cOAL_Source::SetMinMaxDistance(const float afMin, const float afMax)
     RUN_AL_FUNC(alSourcef(mlObjectId, AL_MAX_DISTANCE, afMax));
 }
 
+//////////////////////////////////////////////////////
+//	void SetConeOuterGain(const float afGain)
+//	-	the factor with which AL_GAIN is multiplied to determine the effective gain outside the cone defined by the outer angle
+//////////////////////////////////////////////////////
+
+//--------------------------------------------------------------------------------
+
+void cOAL_Source::SetConeOuterGain(const float afGain)
+{
+	DEF_FUNC_NAME("cOAL_Source::SetConeOuterGain()");
+	FUNC_USES_AL;
+
+    RUN_AL_FUNC(alSourcef(mlObjectId, AL_CONE_OUTER_GAIN , afGain));
+}
+
+//////////////////////////////////////////////////////
+//	void SetConeOuterGainHF(const float afGain)
+//	-	enhances the directivity effect by attenuating high frequencies more than low frequencies in the rear of the source
+//////////////////////////////////////////////////////
+
+//--------------------------------------------------------------------------------
+
+void cOAL_Source::SetConeOuterGainHF(const float afGain)
+{
+	DEF_FUNC_NAME("cOAL_Source::SetConeOuterGainHF()");
+	FUNC_USES_AL;
+
+    RUN_AL_FUNC(alSourcef(mlObjectId, AL_CONE_OUTER_GAINHF , afGain));
+}
+
+//////////////////////////////////////////////////////
+//	void setConeInnerAngle(const float afAngle)
+//	-	Inside angle of the sound cone, in degrees
+//////////////////////////////////////////////////////
+
+//--------------------------------------------------------------------------------
+
+void cOAL_Source::setConeInnerAngle(const float afAngle)
+{
+	DEF_FUNC_NAME("cOAL_Source::setConeInnerAngle()");
+	FUNC_USES_AL;
+
+    RUN_AL_FUNC(alSourcef(mlObjectId, AL_CONE_INNER_ANGLE, afAngle));
+}
+
+//////////////////////////////////////////////////////
+//	void setConeOuterAngle(const float afAngle)
+//	-	Outer angle of the sound cone, in degrees. 
+//////////////////////////////////////////////////////
+
+//--------------------------------------------------------------------------------
+
+void cOAL_Source::setConeOuterAngle(const float afAngle)
+{
+	DEF_FUNC_NAME("cOAL_Source::setConeOuterAngle()");
+	FUNC_USES_AL;
+
+    RUN_AL_FUNC(alSourcef(mlObjectId, AL_CONE_OUTER_ANGLE, afAngle));
+}
+
+//////////////////////////////////////////////////////
+//	void SetDirection(const float* apDir)
+//	-	The sound emission is presumed to be symmetric around the direction vector (cylinder symmetry)
+//////////////////////////////////////////////////////
+
+//--------------------------------------------------------------------------------
+
+void cOAL_Source::SetDirection(const float* apDir)
+{
+	DEF_FUNC_NAME("cOAL_Source::SetDirection()");
+	FUNC_USES_AL;
+
+	RUN_AL_FUNC(alSourcefv ( mlObjectId, AL_DIRECTION, apDir ));
+}
+
+//////////////////////////////////////////////////////
+//	void SetAirAbsortionFactor(const float afFactor)
+//	-	a multiplier on the amount of Air Absorption applied to the Source (0 by default)
+//////////////////////////////////////////////////////
+
+//--------------------------------------------------------------------------------
+
+void cOAL_Source::SetAirAbsorptionFactor(const float afFactor)
+{
+	DEF_FUNC_NAME("cOAL_Source::SetAirAbsorptionFactor()");
+	FUNC_USES_AL;
+
+    RUN_AL_FUNC(alSourcef(mlObjectId, AL_AIR_ABSORPTION_FACTOR, afFactor));
+}
+
+//////////////////////////////////////////////////////
+//	void SetRoomRolloffFactor(const float afFactor)
+//	-	attenuate the reflected sound of this source according to source-listener distance
+//////////////////////////////////////////////////////
+
+//--------------------------------------------------------------------------------
+
+void cOAL_Source::SetRoomRolloffFactor(const float afFactor)
+{
+	DEF_FUNC_NAME("cOAL_Source::SetRoomRolloffFactor()");
+	FUNC_USES_AL;
+
+    RUN_AL_FUNC(alSourcef(mlObjectId, AL_ROOM_ROLLOFF_FACTOR, afFactor));
+}
+
 //--------------------------------------------------------------------------------
 
 void cOAL_Source::SetElapsedTime(double afTime)
@@ -805,6 +910,45 @@ void cOAL_Source::SetAuxSendFilter( int alSendId, cOAL_Filter* apFilter )
 	pSend->SetFilter(apFilter);
 	
 	RUN_AL_FUNC(alSource3i(mlObjectId, AL_AUXILIARY_SEND_FILTER, pSend->GetSlot(), alSendId, pSend->GetFilter()));
+}
+
+//--------------------------------------------------------------------------------
+
+void cOAL_Source::SetDirectFilterGainHFAuto(bool abAuto)
+{
+	if(!gpDevice->IsEFXActive())
+		return;
+
+	DEF_FUNC_NAME("SetDirectFilterGainHFAuto");
+	FUNC_USES_AL;
+	
+	RUN_AL_FUNC(alSourcei(mlObjectId, AL_DIRECT_FILTER_GAINHF_AUTO, (ALint)abAuto));
+}
+
+//--------------------------------------------------------------------------------
+
+void cOAL_Source::SetAuxSendFilterGainAuto(bool abAuto)
+{
+	if(!gpDevice->IsEFXActive())
+		return;
+
+	DEF_FUNC_NAME("SetAuxSendFilterGainAuto");
+	FUNC_USES_AL;
+	
+	RUN_AL_FUNC(alSourcei(mlObjectId, AL_AUXILIARY_SEND_FILTER_GAIN_AUTO, (ALint)abAuto));
+}
+
+//--------------------------------------------------------------------------------
+
+void cOAL_Source::SetAuxSendFilterGainHFAuto(bool abAuto)
+{
+	if(!gpDevice->IsEFXActive())
+		return;
+
+	DEF_FUNC_NAME("SetAuxSendFilterGainHFAuto");
+	FUNC_USES_AL;
+	
+	RUN_AL_FUNC(alSourcei(mlObjectId, AL_AUXILIARY_SEND_FILTER_GAINHF_AUTO, (ALint)abAuto));
 }
 
 //--------------------------------------------------------------------------------


### PR DESCRIPTION
This includes standart OpenAL outer/inner cone angles, source direction
vector as well as stuff introduced in EFX extension, such as air
absorption and outer cone gain HF.

I did not get the logic about what source properties are to be stored on source instance and reset, so followed the same path as SetMinMaxDistance - e.g. do not store anything, do not reset, just call the appropriate OpenAL routines.
